### PR TITLE
TT-983: add address_history and address_history_verified

### DIFF
--- a/src/main/java/uk/gov/ida/saml/hub/domain/UserAccountCreationAttribute.java
+++ b/src/main/java/uk/gov/ida/saml/hub/domain/UserAccountCreationAttribute.java
@@ -23,6 +23,8 @@ public enum UserAccountCreationAttribute implements Serializable {
     DATE_OF_BIRTH_VERIFIED("dateofbirth_verified"),
     CURRENT_ADDRESS("currentaddress"),
     CURRENT_ADDRESS_VERIFIED("currentaddress_verified"),
+    ADDRESS_HISTORY("addresshistory"),
+    ADDRESS_HISTORY_VERIFIED("addresshistory_verified"),
     CYCLE_3("cycle_3");
 
     private String attributeName;


### PR DESCRIPTION
To support passing address history to RPs on account creation, add the address_history
and address_history_verified values to the UserAccountCreationAttribute enum.

Author: @hugh-emerson, @DataMinerUK