### PR TITLE
BAU: Move Builder classes for saml-domain-objects into saml-domain-ob…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,8 @@ dependencies {
             'joda-time:joda-time:2.9',
             'com.google.guava:guava:18.0',
             'uk.gov.ida:security-utils:2.0.0-309',
-            'javax.validation:validation-api:1.1.0.Final'
+            'javax.validation:validation-api:1.1.0.Final',
+            'uk.gov.ida:ida-dev-pki:1.1.0-19'
 
     testCompile "junit:junit:4.11",
             'org.assertj:assertj-core:1.6.0'

--- a/src/main/java/uk/gov/ida/saml/core/test/builders/AddressBuilder.java
+++ b/src/main/java/uk/gov/ida/saml/core/test/builders/AddressBuilder.java
@@ -1,0 +1,75 @@
+package uk.gov.ida.saml.core.test.builders;
+
+import com.google.common.base.Optional;
+import org.joda.time.DateTime;
+import uk.gov.ida.saml.core.domain.Address;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Domain Objects should not be shared across projects .
+ * The aim is to inline all domain objects shared via this project and to get rid of this library
+ *
+ * @deprecated please replicate this class in the project it is used
+ */
+public class AddressBuilder {
+
+    private List<String> lines = new ArrayList<>();
+    private Optional<String> postCode = Optional.absent();
+    private Optional<String> internationalPostCode = Optional.absent();
+    private Optional<String> uprn = Optional.absent();
+    private DateTime fromDate = DateTime.parse("2001-01-01");
+    private Optional<DateTime> toDate = Optional.absent();
+    private boolean verified = false;
+
+    public static AddressBuilder anAddress() {
+        return new AddressBuilder();
+    }
+
+    public Address build() {
+        return new Address(
+                lines,
+                postCode,
+                internationalPostCode,
+                uprn,
+                fromDate,
+                toDate,
+                verified);
+    }
+
+    public AddressBuilder withLines(final List<String> lines) {
+        this.lines = lines;
+        return this;
+    }
+
+    public AddressBuilder withPostCode(final String postCode) {
+        this.postCode = Optional.fromNullable(postCode);
+        return this;
+    }
+
+    public AddressBuilder withInternationalPostCode(final String internationalPostCode) {
+        this.internationalPostCode = Optional.fromNullable(internationalPostCode);
+        return this;
+    }
+
+    public AddressBuilder withUPRN(final String uprn) {
+        this.uprn = Optional.fromNullable(uprn);
+        return this;
+    }
+
+    public AddressBuilder withFromDate(final DateTime fromDate) {
+        this.fromDate = fromDate;
+        return this;
+    }
+
+    public AddressBuilder withToDate(final DateTime toDate) {
+        this.toDate = Optional.fromNullable(toDate);
+        return this;
+    }
+
+    public AddressBuilder withVerified(boolean verified) {
+        this.verified = verified;
+        return this;
+    }
+}

--- a/src/main/java/uk/gov/ida/saml/core/test/builders/AssertionRestrictionsBuilder.java
+++ b/src/main/java/uk/gov/ida/saml/core/test/builders/AssertionRestrictionsBuilder.java
@@ -1,0 +1,43 @@
+package uk.gov.ida.saml.core.test.builders;
+
+import org.joda.time.DateTime;
+import uk.gov.ida.saml.core.domain.AssertionRestrictions;
+
+/**
+ * Domain Objects should not be shared across projects .
+ * The aim is to inline all domain objects shared via this project and to get rid of this library
+ *
+ * @deprecated please replicate this class in the project it is used
+ */
+public class AssertionRestrictionsBuilder {
+
+    private DateTime notOnOrAfter = DateTime.now().plusDays(2);
+    private String inResponseTo = "default-in-response-to";
+    private String recipient = "recipient";
+
+    public static AssertionRestrictionsBuilder anAssertionRestrictions() {
+        return new AssertionRestrictionsBuilder();
+    }
+
+    public AssertionRestrictions build() {
+        return new AssertionRestrictions(
+                notOnOrAfter,
+                inResponseTo,
+                recipient);
+    }
+
+    public AssertionRestrictionsBuilder withNotOnOrAfter(DateTime notOnOrAfter) {
+        this.notOnOrAfter = notOnOrAfter;
+        return this;
+    }
+
+    public AssertionRestrictionsBuilder withInResponseTo(String inResponseTo) {
+        this.inResponseTo = inResponseTo;
+        return this;
+    }
+
+    public AssertionRestrictionsBuilder withRecipient(String recipient) {
+        this.recipient = recipient;
+        return this;
+    }
+}

--- a/src/main/java/uk/gov/ida/saml/core/test/builders/ContactPersonDtoBuilder.java
+++ b/src/main/java/uk/gov/ida/saml/core/test/builders/ContactPersonDtoBuilder.java
@@ -1,0 +1,85 @@
+package uk.gov.ida.saml.core.test.builders;
+
+
+import uk.gov.ida.saml.metadata.domain.ContactPersonDto;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Domain Objects should not be shared across projects .
+ * The aim is to inline all domain objects shared via this project and to get rid of this library
+ *
+ * @deprecated please replicate this class in the project it is used
+ */
+public class ContactPersonDtoBuilder {
+
+    private static final String DEFAULT_TELEPHONE_NUMBER = "0113 496 0000";
+    private static final URI DEFAULT_EMAIL_ADDRESS = URI.create("mailto:default@example.com");
+
+    private String companyName = "default-company-name";
+    private String givenName = "default-given-name";
+    private String surName = "default-sur-name";
+    private List<String> telephoneNumbers = new ArrayList<>();
+    private List<URI> emailAddresses = new ArrayList<>();
+
+    private boolean addDefaultTelephoneNumber = true;
+    private boolean addDefaultEmailAddress = true;
+
+    public static ContactPersonDtoBuilder aContactPersonDto() {
+        return new ContactPersonDtoBuilder();
+    }
+
+    public ContactPersonDto build() {
+        if (addDefaultTelephoneNumber) {
+            telephoneNumbers.add(DEFAULT_TELEPHONE_NUMBER);
+        }
+        if (addDefaultEmailAddress) {
+            emailAddresses.add(DEFAULT_EMAIL_ADDRESS);
+        }
+        return new ContactPersonDto(
+                companyName,
+                givenName,
+                surName,
+                telephoneNumbers,
+                emailAddresses);
+    }
+
+    public ContactPersonDtoBuilder withCompanyName(String companyName) {
+        this.companyName = companyName;
+        return this;
+    }
+
+    public ContactPersonDtoBuilder withGivenName(String givenName) {
+        this.givenName = givenName;
+        return this;
+    }
+
+    public ContactPersonDtoBuilder withSurName(String surName) {
+        this.surName = surName;
+        return this;
+    }
+
+    public ContactPersonDtoBuilder addTelephoneNumber(String number) {
+        telephoneNumbers.add(number);
+        addDefaultTelephoneNumber = false;
+        return this;
+    }
+
+    public ContactPersonDtoBuilder withoutDefaultTelephoneNumber() {
+        addDefaultTelephoneNumber = false;
+        return this;
+    }
+
+    public ContactPersonDtoBuilder addEmailAddress(URI emailAddress) {
+        emailAddresses.add(emailAddress);
+        addDefaultEmailAddress = false;
+        return this;
+    }
+
+    public ContactPersonDtoBuilder withoutDefaultEmailAddress() {
+        addDefaultEmailAddress = false;
+        return this;
+    }
+}

--- a/src/main/java/uk/gov/ida/saml/core/test/builders/Cycle3DatasetBuilder.java
+++ b/src/main/java/uk/gov/ida/saml/core/test/builders/Cycle3DatasetBuilder.java
@@ -1,0 +1,30 @@
+package uk.gov.ida.saml.core.test.builders;
+
+import uk.gov.ida.saml.core.domain.Cycle3Dataset;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Domain Objects should not be shared across projects .
+ * The aim is to inline all domain objects shared via this project and to get rid of this library
+ *
+ * @deprecated please replicate this class in the project it is used
+ */
+public class Cycle3DatasetBuilder {
+
+    private Map<String,String> attributes = new HashMap<>();
+
+    public static Cycle3DatasetBuilder aCycle3Dataset() {
+        return new Cycle3DatasetBuilder();
+    }
+
+    public Cycle3Dataset build() {
+        return Cycle3Dataset.createFromData(attributes);
+    }
+
+    public Cycle3DatasetBuilder addCycle3Data(String name, String value) {
+        attributes.put(name, value);
+        return this;
+    }
+}

--- a/src/main/java/uk/gov/ida/saml/core/test/builders/HubAssertionBuilder.java
+++ b/src/main/java/uk/gov/ida/saml/core/test/builders/HubAssertionBuilder.java
@@ -1,0 +1,74 @@
+package uk.gov.ida.saml.core.test.builders;
+
+import com.google.common.base.Optional;
+import org.joda.time.DateTime;
+import uk.gov.ida.saml.core.domain.AssertionRestrictions;
+import uk.gov.ida.saml.core.domain.Cycle3Dataset;
+import uk.gov.ida.saml.core.domain.HubAssertion;
+import uk.gov.ida.saml.core.domain.PersistentId;
+
+import java.util.UUID;
+
+import static com.google.common.base.Optional.absent;
+import static uk.gov.ida.saml.core.test.builders.AssertionRestrictionsBuilder.anAssertionRestrictions;
+import static uk.gov.ida.saml.core.test.builders.PersistentIdBuilder.aPersistentId;
+
+/**
+ * Domain Objects should not be shared across projects .
+ * The aim is to inline all domain objects shared via this project and to get rid of this library
+ *
+ * @deprecated please replicate this class in the project it is used
+ */
+public class HubAssertionBuilder {
+
+    private String id = "assertion-id" + UUID.randomUUID();
+    private String issuerId = "assertion issuer id";
+    private DateTime issueInstant = DateTime.now();
+    private PersistentId persistentId = aPersistentId().build();
+    private AssertionRestrictions assertionRestrictions = anAssertionRestrictions().build();
+    private Optional<Cycle3Dataset> cycle3Data = absent();
+
+    public static HubAssertionBuilder aHubAssertion() {
+        return new HubAssertionBuilder();
+    }
+
+    public HubAssertion build() {
+        return new HubAssertion(
+                id,
+                issuerId,
+                issueInstant,
+                persistentId,
+                assertionRestrictions,
+                cycle3Data);
+    }
+
+    public HubAssertionBuilder withId(String id) {
+        this.id = id;
+        return this;
+    }
+
+    public HubAssertionBuilder withIssuerId(String issuerId) {
+        this.issuerId = issuerId;
+        return this;
+    }
+
+    public HubAssertionBuilder withIssueInstant(DateTime issueInstant) {
+        this.issueInstant = issueInstant;
+        return this;
+    }
+
+    public HubAssertionBuilder withPersistentId(PersistentId persistentId) {
+        this.persistentId = persistentId;
+        return this;
+    }
+
+    public HubAssertionBuilder withAssertionRestrictions(AssertionRestrictions assertionRestrictions) {
+        this.assertionRestrictions = assertionRestrictions;
+        return this;
+    }
+
+    public HubAssertionBuilder withCycle3Data(Cycle3Dataset cycle3Data) {
+        this.cycle3Data = Optional.fromNullable(cycle3Data);
+        return this;
+    }
+}

--- a/src/main/java/uk/gov/ida/saml/core/test/builders/IdentityProviderAuthnStatementBuilder.java
+++ b/src/main/java/uk/gov/ida/saml/core/test/builders/IdentityProviderAuthnStatementBuilder.java
@@ -1,0 +1,50 @@
+package uk.gov.ida.saml.core.test.builders;
+
+import com.google.common.base.Optional;
+import uk.gov.ida.saml.core.domain.AuthnContext;
+import uk.gov.ida.saml.core.domain.FraudAuthnDetails;
+import uk.gov.ida.saml.core.domain.IdentityProviderAuthnStatement;
+import uk.gov.ida.saml.core.domain.IpAddress;
+
+import static com.google.common.base.Optional.fromNullable;
+import static uk.gov.ida.saml.core.domain.IdentityProviderAuthnStatement.createIdentityProviderAuthnStatement;
+import static uk.gov.ida.saml.core.domain.IdentityProviderAuthnStatement.createIdentityProviderFraudAuthnStatement;
+
+/**
+ * Domain Objects should not be shared across projects .
+ * The aim is to inline all domain objects shared via this project and to get rid of this library
+ *
+ * @deprecated please replicate this class in the project it is used
+ */
+public class IdentityProviderAuthnStatementBuilder {
+
+    private Optional<FraudAuthnDetails> fraudAuthnDetails = Optional.absent();
+    private AuthnContext authnContext = AuthnContext.LEVEL_1;
+    private Optional<IpAddress> userIpAddress = fromNullable(IpAddressBuilder.anIpAddress().build());
+
+    public static IdentityProviderAuthnStatementBuilder anIdentityProviderAuthnStatement() {
+        return new IdentityProviderAuthnStatementBuilder();
+    }
+
+    public IdentityProviderAuthnStatement build() {
+        if (fraudAuthnDetails.isPresent()) {
+            return createIdentityProviderFraudAuthnStatement(fraudAuthnDetails.get(), userIpAddress.orNull());
+        }
+        return createIdentityProviderAuthnStatement(authnContext, userIpAddress.orNull());
+    }
+
+    public IdentityProviderAuthnStatementBuilder withAuthnContext(AuthnContext authnContext) {
+        this.authnContext = authnContext;
+        return this;
+    }
+
+    public IdentityProviderAuthnStatementBuilder withFraudDetails(FraudAuthnDetails fraudDetails) {
+        this.fraudAuthnDetails = Optional.fromNullable(fraudDetails);
+        return this;
+    }
+
+    public IdentityProviderAuthnStatementBuilder withUserIpAddress(IpAddress userIpAddress) {
+        this.userIpAddress = fromNullable(userIpAddress);
+        return this;
+    }
+}

--- a/src/main/java/uk/gov/ida/saml/core/test/builders/IpAddressBuilder.java
+++ b/src/main/java/uk/gov/ida/saml/core/test/builders/IpAddressBuilder.java
@@ -1,0 +1,28 @@
+package uk.gov.ida.saml.core.test.builders;
+
+
+import uk.gov.ida.saml.core.domain.IpAddress;
+
+/**
+ * Domain Objects should not be shared across projects .
+ * The aim is to inline all domain objects shared via this project and to get rid of this library
+ *
+ * @deprecated please replicate this class in the project it is used
+ */
+public class IpAddressBuilder {
+
+    private String ipAddress = "1.2.3.4";
+
+    public static IpAddressBuilder anIpAddress() {
+        return new IpAddressBuilder();
+    }
+
+    public IpAddress build() {
+        return new IpAddress(ipAddress);
+    }
+
+    public IpAddressBuilder withValue(String value) {
+        this.ipAddress = value;
+        return this;
+    }
+}

--- a/src/main/java/uk/gov/ida/saml/core/test/builders/MatchingDatasetBuilder.java
+++ b/src/main/java/uk/gov/ida/saml/core/test/builders/MatchingDatasetBuilder.java
@@ -1,0 +1,119 @@
+package uk.gov.ida.saml.core.test.builders;
+
+import com.google.common.base.Optional;
+import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
+import uk.gov.ida.saml.core.domain.Address;
+import uk.gov.ida.saml.core.domain.AddressFactory;
+import uk.gov.ida.saml.core.domain.Gender;
+import uk.gov.ida.saml.core.domain.MatchingDataset;
+import uk.gov.ida.saml.core.domain.SimpleMdsValue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.google.common.base.Optional.absent;
+import static com.google.common.base.Optional.fromNullable;
+import static java.util.Arrays.asList;
+
+/**
+ * Domain Objects should not be shared across projects .
+ * The aim is to inline all domain objects shared via this project and to get rid of this library
+ *
+ * @deprecated please replicate this class in the project it is used
+ */
+public class MatchingDatasetBuilder {
+
+    private List<SimpleMdsValue<String>> firstnames = new ArrayList<>();
+    private List<SimpleMdsValue<String>> middleNames = new ArrayList<>();
+    private List<SimpleMdsValue<String>> surnames = new ArrayList<>();
+    private Optional<SimpleMdsValue<Gender>> gender = absent();
+    private List<SimpleMdsValue<LocalDate>> dateOfBirths = new ArrayList<>();
+    private List<Address> currentAddresses = new ArrayList<>();
+    private List<Address> previousAddresses = new ArrayList<>();
+
+    public static MatchingDatasetBuilder aMatchingDataset() {
+        return new MatchingDatasetBuilder();
+    }
+
+    public static MatchingDatasetBuilder aFullyPopulatedMatchingDataset() {
+        final List<Address> currentAddressList = asList(new AddressFactory().create(asList("subject-address-line-1"), "subject-address-post-code", "internation-postcode", "uprn", DateTime.parse("1999-03-15"), DateTime.parse("2000-02-09"), true));
+        final List<Address> previousAddressList = asList(new AddressFactory().create(asList("previous-address-line-1"), "subject-address-post-code", "internation-postcode", "uprn", DateTime.parse("1999-03-15"), DateTime.parse("2000-02-09"), true));
+        final SimpleMdsValue<String> currentSurname = SimpleMdsValueBuilder.<String>aSimpleMdsValue().withValue("subject-currentSurname").withVerifiedStatus(true).build();
+        return aMatchingDataset()
+                .addFirstname(SimpleMdsValueBuilder.<String>aSimpleMdsValue().withValue("subject-firstname").withVerifiedStatus(true).build())
+                .addMiddleNames(SimpleMdsValueBuilder.<String>aSimpleMdsValue().withValue("subject-middlename").withVerifiedStatus(true).build())
+                .withSurnameHistory(asList(currentSurname))
+                .withGender(SimpleMdsValueBuilder.<Gender>aSimpleMdsValue().withValue(Gender.FEMALE).withVerifiedStatus(true).build())
+                .addDateOfBirth(SimpleMdsValueBuilder.<LocalDate>aSimpleMdsValue().withValue(LocalDate.parse("2000-02-09")).withVerifiedStatus(true).build())
+                .withCurrentAddresses(currentAddressList)
+                .withPreviousAddresses(previousAddressList);
+    }
+
+    public MatchingDataset build() {
+        return new MatchingDataset(firstnames, middleNames, surnames, gender, dateOfBirths, currentAddresses, previousAddresses);
+    }
+
+    public MatchingDatasetBuilder addFirstname(SimpleMdsValue<String> firstname) {
+        this.firstnames.add(firstname);
+        return this;
+    }
+
+    public MatchingDatasetBuilder addMiddleNames(SimpleMdsValue<String> middleNames) {
+        this.middleNames.add(middleNames);
+        return this;
+    }
+
+    public MatchingDatasetBuilder addSurname(SimpleMdsValue<String> surname) {
+        this.surnames.add(surname);
+        return this;
+    }
+
+    public MatchingDatasetBuilder withGender(SimpleMdsValue<Gender> gender) {
+        this.gender = fromNullable(gender);
+        return this;
+    }
+
+    public MatchingDatasetBuilder addDateOfBirth(SimpleMdsValue<LocalDate> dateOfBirth) {
+        this.dateOfBirths.add(dateOfBirth);
+        return this;
+    }
+
+    public MatchingDatasetBuilder withCurrentAddresses(List<Address> currentAddresses) {
+        this.currentAddresses = currentAddresses;
+        return this;
+    }
+
+    public MatchingDatasetBuilder withPreviousAddresses(List<Address> previousAddresses) {
+        this.previousAddresses = previousAddresses;
+        return this;
+    }
+
+    public MatchingDatasetBuilder withoutFirstName() {
+        this.firstnames.clear();
+        return this;
+    }
+
+    public MatchingDatasetBuilder withoutMiddleName() {
+        this.middleNames.clear();
+        return this;
+    }
+
+    public MatchingDatasetBuilder withoutSurname() {
+        this.surnames.clear();
+        return this;
+    }
+
+    public MatchingDatasetBuilder withoutDateOfBirth() {
+        this.dateOfBirths.clear();
+        return this;
+    }
+
+    public MatchingDatasetBuilder withSurnameHistory(
+            final List<SimpleMdsValue<String>> surnameHistory) {
+
+        this.surnames.clear();
+        this.surnames.addAll(surnameHistory);
+        return this;
+    }
+}

--- a/src/main/java/uk/gov/ida/saml/core/test/builders/OrganisationDtoBuilder.java
+++ b/src/main/java/uk/gov/ida/saml/core/test/builders/OrganisationDtoBuilder.java
@@ -1,0 +1,37 @@
+package uk.gov.ida.saml.core.test.builders;
+
+
+import uk.gov.ida.saml.metadata.domain.OrganisationDto;
+
+/**
+ * Domain Objects should not be shared across projects .
+ * The aim is to inline all domain objects shared via this project and to get rid of this library
+ *
+ * @deprecated please replicate this class in the project it is used
+ */
+public class OrganisationDtoBuilder {
+
+    private String organisationDisplayName = "Display Name";
+    private String organisationName = "MegaCorp";
+
+    public static OrganisationDtoBuilder anOrganisationDto() {
+        return new OrganisationDtoBuilder();
+    }
+
+    public OrganisationDto build() {
+        return new OrganisationDto(
+                organisationDisplayName,
+                organisationName,
+                "https://hub.ida.gov.uk");
+    }
+
+    public OrganisationDtoBuilder withDisplayName(String organisationDisplayName) {
+        this.organisationDisplayName = organisationDisplayName;
+        return this;
+    }
+
+    public OrganisationDtoBuilder withName(String organisationName) {
+        this.organisationName = organisationName;
+        return this;
+    }
+}

--- a/src/main/java/uk/gov/ida/saml/core/test/builders/PersistentIdBuilder.java
+++ b/src/main/java/uk/gov/ida/saml/core/test/builders/PersistentIdBuilder.java
@@ -1,0 +1,27 @@
+package uk.gov.ida.saml.core.test.builders;
+
+import uk.gov.ida.saml.core.domain.PersistentId;
+
+/**
+ * Domain Objects should not be shared across projects .
+ * The aim is to inline all domain objects shared via this project and to get rid of this library
+ *
+ * @deprecated please replicate this class in the project it is used
+ */
+public class PersistentIdBuilder {
+
+    private String nameId = "default-name-id";
+
+    public static PersistentIdBuilder aPersistentId() {
+        return new PersistentIdBuilder();
+    }
+
+    public PersistentId build() {
+        return new PersistentId(nameId);
+    }
+
+    public PersistentIdBuilder withNameId(String persistentId) {
+        this.nameId = persistentId;
+        return this;
+    }
+}

--- a/src/main/java/uk/gov/ida/saml/core/test/builders/ResponseForHubBuilder.java
+++ b/src/main/java/uk/gov/ida/saml/core/test/builders/ResponseForHubBuilder.java
@@ -1,0 +1,131 @@
+package uk.gov.ida.saml.core.test.builders;
+
+import org.joda.time.DateTime;
+import org.opensaml.xmlsec.signature.Signature;
+import uk.gov.ida.saml.core.domain.IdpIdaStatus;
+import uk.gov.ida.saml.core.domain.InboundResponseFromIdp;
+import uk.gov.ida.saml.core.domain.OutboundResponseFromHub;
+import uk.gov.ida.saml.core.domain.PassthroughAssertion;
+import uk.gov.ida.saml.core.domain.TransactionIdaStatus;
+import uk.gov.ida.saml.core.test.TestEntityIds;
+
+import java.net.URI;
+import java.util.Optional;
+
+import static java.util.Optional.empty;
+import static java.util.Optional.ofNullable;
+
+/**
+ * Domain Objects should not be shared across projects .
+ * The aim is to inline all domain objects shared via this project and to get rid of this library
+ *
+ * @deprecated please replicate this class in the project it is used
+ */
+public class ResponseForHubBuilder {
+
+    private String responseId = "response-id";
+    private String inResponseTo = "request-id";
+    private String issuerId = "issuer-id";
+    private DateTime issueInstant = DateTime.now();
+    private TransactionIdaStatus transactionIdpStatus = TransactionIdaStatus.Success;
+    private IdpIdaStatus idpIdaStatus = IdpIdaStatus.success();
+    private Optional<Signature> signature = null;
+    private Optional<PassthroughAssertion> authnStatementAssertion = empty();
+    private Optional<PassthroughAssertion> matchingDatasetAssertion = empty();
+    private Optional<String> matchingServiceAssertion = empty();
+
+
+    public static ResponseForHubBuilder anAuthnResponse() {
+        return new ResponseForHubBuilder();
+    }
+
+    public InboundResponseFromIdp buildInboundFromIdp() {
+        return new InboundResponseFromIdp(
+                responseId,
+                inResponseTo,
+                issuerId,
+                issueInstant,
+                idpIdaStatus,
+                signature,
+                matchingDatasetAssertion,
+                null,
+                authnStatementAssertion
+        );
+    }
+
+    public InboundResponseFromIdp buildSuccessFromIdp() {
+        return new InboundResponseFromIdp(
+                responseId,
+                inResponseTo,
+                issuerId,
+                issueInstant,
+                idpIdaStatus,
+                signature,
+                matchingDatasetAssertion,
+                null,
+                authnStatementAssertion
+        );
+    }
+
+    public OutboundResponseFromHub buildOutboundResponseFromHub() {
+        return new OutboundResponseFromHub(
+                responseId,
+                inResponseTo,
+                TestEntityIds.HUB_ENTITY_ID,
+                issueInstant,
+                transactionIdpStatus,
+                matchingServiceAssertion,
+                URI.create("blah"));
+    }
+
+
+    public ResponseForHubBuilder withResponseId(String responseId) {
+        this.responseId = responseId;
+        return this;
+    }
+
+    public ResponseForHubBuilder withInResponseTo(String inResponseTo) {
+        this.inResponseTo = inResponseTo;
+        return this;
+    }
+
+    public ResponseForHubBuilder withIssuerId(String issuerId) {
+        this.issuerId = issuerId;
+        return this;
+    }
+
+    public ResponseForHubBuilder withIssueInstant(DateTime issueInstant) {
+        this.issueInstant = issueInstant;
+        return this;
+    }
+
+    public ResponseForHubBuilder withIdpIdaStatus(IdpIdaStatus status) {
+        this.idpIdaStatus = status;
+        return this;
+    }
+
+    public ResponseForHubBuilder withTransactionIdaStatus(TransactionIdaStatus status) {
+        this.transactionIdpStatus = status;
+        return this;
+    }
+
+    public ResponseForHubBuilder withSignature(Signature signature) {
+        this.signature = ofNullable(signature);
+        return this;
+    }
+
+    public ResponseForHubBuilder withAuthnStatementAssertion(PassthroughAssertion authnStatementAssertion) {
+        this.authnStatementAssertion = ofNullable(authnStatementAssertion);
+        return this;
+    }
+
+    public ResponseForHubBuilder withMatchingDatasetAssertion(PassthroughAssertion matchingDatasetAssertion) {
+        this.matchingDatasetAssertion = ofNullable(matchingDatasetAssertion);
+        return this;
+    }
+
+    public ResponseForHubBuilder withMatchingServiceAssertion(String matchingServiceAssertion) {
+        this.matchingServiceAssertion = ofNullable(matchingServiceAssertion);
+        return this;
+    }
+}

--- a/src/main/java/uk/gov/ida/saml/core/test/builders/SimpleMdsValueBuilder.java
+++ b/src/main/java/uk/gov/ida/saml/core/test/builders/SimpleMdsValueBuilder.java
@@ -1,0 +1,47 @@
+package uk.gov.ida.saml.core.test.builders;
+
+import org.joda.time.DateTime;
+import uk.gov.ida.saml.core.domain.SimpleMdsValue;
+
+/**
+ * Domain Objects should not be shared across projects .
+ * The aim is to inline all domain objects shared via this project and to get rid of this library
+ *
+ * @deprecated please replicate this class in the project it is used
+ */
+public class SimpleMdsValueBuilder<T> {
+
+    private T value = null;
+
+    private DateTime from = DateTime.now().minusDays(5);
+    private DateTime to = DateTime.now().plusDays(5);
+    private boolean verified = false;
+
+    public static <T> SimpleMdsValueBuilder<T> aSimpleMdsValue() {
+        return new SimpleMdsValueBuilder<>();
+    }
+
+    public SimpleMdsValue<T> build() {
+        return new SimpleMdsValue<>(value, from, to, verified);
+    }
+
+    public SimpleMdsValueBuilder<T> withValue(T value) {
+        this.value = value;
+        return this;
+    }
+
+    public SimpleMdsValueBuilder<T> withFrom(DateTime from) {
+        this.from = from;
+        return this;
+    }
+
+    public SimpleMdsValueBuilder<T> withTo(DateTime to) {
+        this.to = to;
+        return this;
+    }
+
+    public SimpleMdsValueBuilder<T> withVerifiedStatus(boolean verified) {
+        this.verified = verified;
+        return this;
+    }
+}

--- a/src/main/java/uk/gov/ida/saml/core/test/builders/metadata/AssertionConsumerServiceEndpointDtoBuilder.java
+++ b/src/main/java/uk/gov/ida/saml/core/test/builders/metadata/AssertionConsumerServiceEndpointDtoBuilder.java
@@ -1,0 +1,44 @@
+package uk.gov.ida.saml.core.test.builders.metadata;
+
+import uk.gov.ida.saml.metadata.domain.AssertionConsumerServiceEndpointDto;
+
+import java.net.URI;
+
+/**
+ * Domain Objects should not be shared across projects .
+ * The aim is to inline all domain objects shared via this project and to get rid of this library
+ *
+ * @deprecated please replicate this class in the project it is used
+ */
+public class AssertionConsumerServiceEndpointDtoBuilder {
+
+    private URI location = URI.create("https://hub.ida.gov.uk/blah");
+    private boolean isDefault = false;
+    private int index = 0;
+
+    public static AssertionConsumerServiceEndpointDtoBuilder anAssertionConsumerServiceEndpointDto() {
+        return new AssertionConsumerServiceEndpointDtoBuilder();
+    }
+
+    public AssertionConsumerServiceEndpointDto build() {
+        return new AssertionConsumerServiceEndpointDto(
+                location,
+                isDefault,
+                index);
+    }
+
+    public AssertionConsumerServiceEndpointDtoBuilder withLocation(URI location) {
+        this.location = location;
+        return this;
+    }
+
+    public AssertionConsumerServiceEndpointDtoBuilder isDefault() {
+        isDefault = true;
+        return this;
+    }
+
+    public AssertionConsumerServiceEndpointDtoBuilder withIndex(int index) {
+        this.index = index;
+        return this;
+    }
+}


### PR DESCRIPTION
…jects

These classes are all just Builders of classes defined in saml-domain-objects.
Previously these builder classes lived in saml-test-utils.
This created an unnessesary dependency between the two libraries.
Moving the classes into this library moves them closer to the objects that
they relate to, and allows us to break the dependency of saml-test-utils
on saml-domain-objects.

I have also marked all of the moved classes as deprecated, as they serve
only to build deprecated classes.

Solo: @michaelwalker